### PR TITLE
Update main.lua

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1183,7 +1183,11 @@ if (isfolder and isfolder("fates-admin") and isfolder("fates-admin/plugins") and
     local Plugins = table.map(table.filter(listfiles("fates-admin/plugins"), function(i, v)
         return v:split(".")[#v:split(".")]:lower() == "lua"
     end), function(i, v)
-        return {v:split("\\")[2], loadfile(v)}
+        if identifyexecutor and identifyexecutor() == "ScriptWare" then
+            return {v:split("\\")[2], loadfile("fates-admin/plugins"..v)}
+        else
+            return {v:split("\\")[2], loadfile(v)}
+        end
     end)
 
     for i, v in next, Plugins do


### PR DESCRIPTION
Fixes bug where on Script-Ware if there is plugins in the plugin folder, it would error and not run. This was caused because on Script-Ware, the listfiles function works differently, and only displays "\\" and the name of the file, instead of the path.