### PR TITLE
Fix plugins on Script-Ware

### DIFF
--- a/src/lua/admin.plugin.lua
+++ b/src/lua/admin.plugin.lua
@@ -49,11 +49,7 @@ do
         return lower(split(v, ".")[#split(v, ".")]) == "lua"
     end), function(i, v)
         local splitted = split(v, "\\");
-        if (identifyexecutor and identifyexecutor() == "ScriptWare") then
-            return {splitted[#splitted], loadfile("fates-admin/plugins/" .. v)}
-        else
-            return {splitted[#splitted], loadfile(v)}
-        end
+        return {splitted[#splitted], loadfile(v)}
     end) or {}
 
     if (SafePlugins) then


### PR DESCRIPTION
Script-Ware's listfiles() function previously returned only file and folder names without their full path. This has since been patched and Script-Ware's listfiles() implementation is consistent with other executors. The workaround used here now causes errors when loading plugins on Script-Ware as the path to the plugins folder is repeated twice.